### PR TITLE
Add mood analysis endpoint and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ npm install
 npm start
 ```
 
+Once the server is running, try the Mood-Mirror API:
+
+```bash
+curl "http://localhost:3000/mood?file=sample.wav"
+```
+
+Or open the notebook at `python/notebooks/demo_mood_mirror.ipynb`.
+
 ## Sprint Cadence
 | Sprint | Duration | Focus | Deliverables | Fidelity & Support |
 |--------|----------|-------|--------------|--------------------|

--- a/node/index.js
+++ b/node/index.js
@@ -11,8 +11,8 @@ app.get('/', (req, res) => {
 
 app.get('/mood', (req, res) => {
   const file = req.query.file;
-  if (!file) {
-    return res.status(400).json({ error: 'Missing file parameter' });
+  if (!file || /[^\w.-]/.test(file)) {
+    return res.status(400).json({ error: 'Missing or invalid file parameter' });
   }
 
   const scriptPath = path.join(__dirname, '..', 'python', 'mood_analysis.py');

--- a/node/index.js
+++ b/node/index.js
@@ -1,4 +1,6 @@
 const express = require('express');
+const { spawn } = require('child_process');
+const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -7,8 +9,37 @@ app.get('/', (req, res) => {
   res.json({ status: 'AI Pin API ready' });
 });
 
-app.use((req, res) => {
-  res.status(404).json({ error: 'Not Found' });
+app.get('/mood', (req, res) => {
+  const file = req.query.file;
+  if (!file) {
+    return res.status(400).json({ error: 'Missing file parameter' });
+  }
+
+  const scriptPath = path.join(__dirname, '..', 'python', 'mood_analysis.py');
+  const py = spawn('python', [scriptPath, file]);
+
+  let stdout = '';
+  let stderr = '';
+
+  py.stdout.on('data', (data) => {
+    stdout += data;
+  });
+
+  py.stderr.on('data', (data) => {
+    stderr += data;
+  });
+
+  py.on('close', (code) => {
+    if (code !== 0) {
+      return res.status(500).json({ error: stderr.trim() || 'Python process failed' });
+    }
+    try {
+      const result = JSON.parse(stdout);
+      res.json(result);
+    } catch (err) {
+      res.status(500).json({ error: 'Invalid JSON from Python script' });
+    }
+  });
 });
 
 app.use((req, res) => {

--- a/node/index.js
+++ b/node/index.js
@@ -16,7 +16,7 @@ app.get('/mood', (req, res) => {
   }
 
   const scriptPath = path.join(__dirname, '..', 'python', 'mood_analysis.py');
-  const py = spawn('python', [scriptPath, file]);
+  const py = spawn('python3', [scriptPath, file]);
 
   let stdout = '';
   let stderr = '';

--- a/python/mood_analysis.py
+++ b/python/mood_analysis.py
@@ -5,6 +5,17 @@ import numpy as np
 import librosa
 import whisper
 
+HIGH_WPM_THRESHOLD = 160
+MEDIUM_WPM_THRESHOLD = 120
+HIGH_RMS_THRESHOLD = 0.05
+MEDIUM_RMS_THRESHOLD = 0.03
+
+SUGGESTIONS = {
+    "low": "You're sounding relaxed. Keep it up!",
+    "medium": "Take a deep breath and slow down a bit.",
+    "high": "Pause and breathe deeply to calm yourself.",
+}
+
 
 def main():
     if len(sys.argv) < 2:
@@ -26,20 +37,14 @@ def main():
         words = len(result.get("text", "").strip().split())
         wpm = words / duration_minutes if duration_minutes > 0 else 0
 
-        if wpm > 160 or rms > 0.05:
+        if wpm > HIGH_WPM_THRESHOLD or rms > HIGH_RMS_THRESHOLD:
             level = "high"
-        elif wpm > 120 or rms > 0.03:
+        elif wpm > MEDIUM_WPM_THRESHOLD or rms > MEDIUM_RMS_THRESHOLD:
             level = "medium"
         else:
             level = "low"
 
-        suggestions = {
-            "low": "You're sounding relaxed. Keep it up!",
-            "medium": "Take a deep breath and slow down a bit.",
-            "high": "Pause and breathe deeply to calm yourself.",
-        }
-
-        print(json.dumps({"stress_level": level, "suggestion": suggestions[level]}))
+        print(json.dumps({"stress_level": level, "suggestion": SUGGESTIONS[level]}))
     except Exception as e:
         print(str(e), file=sys.stderr)
         sys.exit(1)

--- a/python/mood_analysis.py
+++ b/python/mood_analysis.py
@@ -34,7 +34,8 @@ def main():
 
         model = whisper.load_model("tiny")
         result = model.transcribe(audio_path)
-        words = len(result.get("text", "").strip().split())
+        text = result.get("text", "").strip()
+        words = len(text.split()) if text else 0
         wpm = words / duration_minutes if duration_minutes > 0 else 0
 
         if wpm > HIGH_WPM_THRESHOLD or rms > HIGH_RMS_THRESHOLD:

--- a/python/mood_analysis.py
+++ b/python/mood_analysis.py
@@ -1,0 +1,49 @@
+import sys
+import os
+import json
+import numpy as np
+import librosa
+import whisper
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Missing file path", file=sys.stderr)
+        sys.exit(1)
+
+    audio_path = sys.argv[1]
+    if not os.path.isfile(audio_path):
+        print("File not found", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        audio, sr = librosa.load(audio_path, sr=None)
+        duration_minutes = len(audio) / sr / 60.0 if sr else 0
+        rms = float(np.sqrt(np.mean(audio ** 2))) if len(audio) else 0
+
+        model = whisper.load_model("tiny")
+        result = model.transcribe(audio_path)
+        words = len(result.get("text", "").strip().split())
+        wpm = words / duration_minutes if duration_minutes > 0 else 0
+
+        if wpm > 160 or rms > 0.05:
+            level = "high"
+        elif wpm > 120 or rms > 0.03:
+            level = "medium"
+        else:
+            level = "low"
+
+        suggestions = {
+            "low": "You're sounding relaxed. Keep it up!",
+            "medium": "Take a deep breath and slow down a bit.",
+            "high": "Pause and breathe deeply to calm yourself.",
+        }
+
+        print(json.dumps({"stress_level": level, "suggestion": suggestions[level]}))
+    except Exception as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/notebooks/demo_mood_mirror.ipynb
+++ b/python/notebooks/demo_mood_mirror.ipynb
@@ -2,8 +2,35 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "1401bea4",
    "metadata": {},
-   "source": ["# Mood-Mirror prototype – TLC"]
+   "source": [
+    "# Mood-Mirror Coach demo\n",
+    "This notebook calls the local Node API to analyze vocal stress from an audio sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3cebba9c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'stress_level': 'low', 'suggestion': \"You're sounding relaxed. Keep it up!\"}"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import requests, json\n",
+    "r = requests.get(\"http://localhost:3000/mood\", params={\"file\":\"sample.wav\"})\n",
+    "r.json()"
+   ]
   }
  ],
  "metadata": {

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,3 +3,6 @@ opencv-python==4.9.0.80
 openai-whisper==20231117
 yolov5==7.0.14
 jupyterlab==4.2.3
+librosa==0.10.1
+soundfile==0.12.1
+requests==2.31.0


### PR DESCRIPTION
## Summary
- implement `/mood` endpoint that delegates stress analysis to a Python helper
- add Python `mood_analysis.py` using Whisper transcription and RMS volume for simple stress heuristics
- provide demo notebook and README note for invoking the API

## Testing
- `npm test` (fails: Missing script: "test")
- `python -m py_compile python/mood_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68942cb2e40c832badbe943e59ba3f32