### PR TITLE
Refactor mood analysis into persistent service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Run the mood analysis service:
 
 ```bash
 cd python
-python mood_service.py
+gunicorn -b 0.0.0.0:5000 mood_service:app
 ```
+The above uses Gunicorn for a production-ready server. For quick local testing you can still run `python mood_service.py`.
 
 ### Node
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
 pip install -r python/requirements.txt
 ```
 
+Run the mood analysis service:
+
+```bash
+cd python
+python mood_service.py
+```
+
 ### Node
 ```bash
 cd node
@@ -23,7 +30,7 @@ npm install
 npm start
 ```
 
-Once the server is running, try the Mood-Mirror API:
+Once both servers are running, try the Mood-Mirror API:
 
 ```bash
 curl "http://localhost:3000/mood?file=sample.wav"

--- a/node/index.js
+++ b/node/index.js
@@ -21,10 +21,29 @@ app.get('/mood', async (req, res) => {
     const url = new URL('/mood', PYTHON_SERVICE_URL);
     url.searchParams.set('file', audioPath);
     const response = await fetch(url);
-    const data = await response.json();
-    res.status(response.status).json(data);
+    const text = await response.text();
+
+    if (!response.ok) {
+      console.error('Python service error:', response.status, text);
+      return res
+        .status(response.status)
+        .json({ error: 'Python service error', details: text });
+    }
+
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch (parseErr) {
+      console.error('Invalid JSON from Python service:', text);
+      return res.status(500).json({ error: 'Invalid response from Python service' });
+    }
+
+    res.json(data);
   } catch (err) {
-    res.status(500).json({ error: 'Python service request failed' });
+    console.error('Failed to call Python service:', err);
+    res
+      .status(500)
+      .json({ error: 'Python service request failed', details: err.message });
   }
 });
 

--- a/node/index.js
+++ b/node/index.js
@@ -1,45 +1,31 @@
 const express = require('express');
-const { spawn } = require('child_process');
 const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const PYTHON_SERVICE_URL = process.env.PYTHON_SERVICE_URL || 'http://localhost:5000';
 
 app.get('/', (req, res) => {
   res.json({ status: 'AI Pin API ready' });
 });
 
-app.get('/mood', (req, res) => {
+app.get('/mood', async (req, res) => {
   const file = req.query.file;
   if (!file || /[^\w.-]/.test(file)) {
     return res.status(400).json({ error: 'Missing or invalid file parameter' });
   }
 
-  const scriptPath = path.join(__dirname, '..', 'python', 'mood_analysis.py');
-  const py = spawn('python3', [scriptPath, file]);
+  const audioPath = path.join(__dirname, '..', file);
 
-  let stdout = '';
-  let stderr = '';
-
-  py.stdout.on('data', (data) => {
-    stdout += data;
-  });
-
-  py.stderr.on('data', (data) => {
-    stderr += data;
-  });
-
-  py.on('close', (code) => {
-    if (code !== 0) {
-      return res.status(500).json({ error: stderr.trim() || 'Python process failed' });
-    }
-    try {
-      const result = JSON.parse(stdout);
-      res.json(result);
-    } catch (err) {
-      res.status(500).json({ error: 'Invalid JSON from Python script' });
-    }
-  });
+  try {
+    const url = new URL('/mood', PYTHON_SERVICE_URL);
+    url.searchParams.set('file', audioPath);
+    const response = await fetch(url);
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Python service request failed' });
+  }
 });
 
 app.use((req, res) => {

--- a/python/mood_service.py
+++ b/python/mood_service.py
@@ -1,0 +1,21 @@
+from flask import Flask, request, jsonify
+import os
+
+from mood_analysis import analyze_mood
+
+app = Flask(__name__)
+
+
+@app.get("/mood")
+def mood():
+    file = request.args.get("file")
+    if not file or not os.path.isfile(file):
+        return jsonify({"error": "Missing or invalid file parameter"}), 400
+    try:
+        return jsonify(analyze_mood(file))
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/python/mood_service.py
+++ b/python/mood_service.py
@@ -18,4 +18,7 @@ def mood():
 
 
 if __name__ == "__main__":
+    # The built-in Flask server is for local development only.
+    # For production, run with a WSGI server such as:
+    #   gunicorn -b 0.0.0.0:5000 mood_service:app
     app.run(host="0.0.0.0", port=5000)

--- a/python/mood_service.py
+++ b/python/mood_service.py
@@ -8,11 +8,19 @@ app = Flask(__name__)
 
 @app.get("/mood")
 def mood():
-    file = request.args.get("file")
-    if not file or not os.path.isfile(file):
-        return jsonify({"error": "Missing or invalid file parameter"}), 400
+    file_path = request.args.get("file")
+    if not file_path:
+        return jsonify({"error": "Missing file parameter"}), 400
+
+    # Security: ensure file is within project directory and is a file
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    abs_path = os.path.abspath(file_path)
+
+    if not abs_path.startswith(project_root) or not os.path.isfile(abs_path):
+        return jsonify({"error": "File is invalid or outside allowed directory"}), 400
+
     try:
-        return jsonify(analyze_mood(file))
+        return jsonify(analyze_mood(abs_path))
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,3 +6,4 @@ jupyterlab==4.2.3
 librosa==0.10.1
 soundfile==0.12.1
 requests==2.31.0
+flask==3.0.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,4 @@ librosa==0.10.1
 soundfile==0.12.1
 requests==2.31.0
 flask==3.0.3
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- load Whisper model once and expose `analyze_mood` utility
- serve mood analysis through a Flask app so the model stays in memory
- call the Python service from Node and document the new workflow

## Testing
- `python -m py_compile python/mood_analysis.py python/mood_service.py`
- `node --check node/index.js`
- `cd node && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689436a6859c832bbcbfeacb598dbfb2